### PR TITLE
Fix distortion in training data resizing for non-square images

### DIFF
--- a/dataset.py
+++ b/dataset.py
@@ -59,7 +59,7 @@ def prepare_data(data_path, patch_size, stride, aug_times=1, mode='gray'):
             if mode == 'color':
                 if int(h * scales[k]) < 256 or int(w * scales[k]) < 256:
                     continue
-            Img = cv2.resize(img, (int(h * scales[k]), int(w * scales[k])), interpolation=cv2.INTER_CUBIC)
+            Img = cv2.resize(img, (int(w * scales[k]), int(h * scales[k])), interpolation=cv2.INTER_CUBIC)
             # Img = img.resize( (int(h * scales[k]), int(w * scales[k])))
             if mode =='gray':
                 Img = np.expand_dims(Img[:, :, 0].copy(), 0)


### PR DESCRIPTION
This Pull Request addresses an issue in the training data preparation process where non-square images were being resized with swapped width and height parameters in the `cv2.resize` function. The issue caused distortion in the training data, affecting datasets with predominantly non-square images, such as PASCAL VOC 2012.

**Changes Made:**  
- Corrected the parameter order in the `cv2.resize` function from `(height, width)` to `(width, height)`.
- Ensured resized training images maintain their original aspect ratio, avoiding distortion.
- Verified that extracted patches reflect the correct image dimensions and distribution.

**Impact:**  
This fix ensures consistency between the training and testing datasets, potentially improving model performance by training on undistorted images. This is important, because during testing no comparable distortion is performed. This PR fixes #3 

**Testing:**  
- Verified that non-square training images are now being resized correctly and maintain their aspect ratio.
- Checked extracted patches to confirm they are undistorted.